### PR TITLE
feat: Integrate Winston for centralized logging

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,9 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import logger from "./src/logger";
+
+logger.info('✅ Winston logger initialized – startup check');
 
 const app = express();
 app.use(express.json());

--- a/server/src/logger/index.ts
+++ b/server/src/logger/index.ts
@@ -1,0 +1,40 @@
+import winston from 'winston';
+import path from 'path';
+import fs from 'fs';
+
+const centralizedLogFile = '/home/zk/logs/tabletamer.log';
+const centralizedLogDir = path.dirname(centralizedLogFile);
+if (!fs.existsSync(centralizedLogDir)) {
+  fs.mkdirSync(centralizedLogDir, { recursive: true });
+}
+
+const { combine, timestamp, json, errors, colorize, printf } = winston.format;
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: combine(
+    timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    errors({ stack: true }),
+    json()
+  ),
+  defaultMeta: { service: 'tabletamer' },
+  transports: [
+    new winston.transports.File({ filename: centralizedLogFile }),
+  ],
+});
+
+if (process.env.NODE_ENV !== 'production') {
+  logger.add(new winston.transports.Console({
+    format: combine(
+      colorize(),
+      timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+      printf(({ level, message, timestamp, stack, service }) => {
+        let logMsg = `${timestamp} ${level} [${service}]: ${message}`;
+        if (stack) logMsg += `\n${stack}`;
+        return logMsg;
+      })
+    ),
+  }));
+}
+
+export default logger;

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -8,15 +8,12 @@ import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();
 
-export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
+import logger from "./src/logger";
 
-  console.log(`${formattedTime} [${source}] ${message}`);
+export function log(message: string, source = "express") {
+  // The Winston logger already includes a timestamp and service name.
+  // We can simplify this function to just pass the message and source.
+  logger.info(`[${source}] ${message}`);
 }
 
 export async function setupVite(app: Express, server: Server) {


### PR DESCRIPTION
- Added Winston logger module for centralized logging to /home/zk/logs/tabletamer.log.
- Enables console logging in non-production environments.
- Integrated logger into the application startup and replaced existing custom `log` function in `server/vite.ts`.
- The logger module creates the log directory and file if they don't exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a centralized logging system with enhanced formatting, timestamps, and error stack traces.
  - Logs are now written to a dedicated log file, with colorized console output in non-production environments.
- **Chores**
  - Standardized server logging to use the new centralized logger across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->